### PR TITLE
fix: update ether with fra

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_balance_card.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_balance_card.html.eex
@@ -15,7 +15,7 @@
             data-wei-value="<%= if @address.fetched_coin_balance, do: @address.fetched_coin_balance.value %>"
             data-usd-exchange-rate="<%= @exchange_rate.usd_value %>">
           </span>
-          <small>(@ <span data-usd-unit-price="<%= @exchange_rate.usd_value %>"></span>/<%= gettext("Ether") %>)</small>
+          <small>(@ <span data-usd-unit-price="<%= @exchange_rate.usd_value %>"></span>/<%= gettext("FRA") %>)</small>
         </p>
       <% end %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
@@ -17,7 +17,7 @@
       </span>
       <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
         <span class="tile-title">
-          <%= BlockScoutWeb.TransactionView.value(@internal_transaction, include_label: false) %> <%= gettext "Ether" %>
+          <%= BlockScoutWeb.TransactionView.value(@internal_transaction, include_label: false) %> <%= gettext "FRA" %>
         </span>
       </span>
     </div>


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

There was an issue found on the explorer 

![CleanShot 2022-03-03 at 14 49 42](https://user-images.githubusercontent.com/1706749/156641827-dd2405c5-0476-4f60-b699-03c788418438.png)

https://prod-testnet-blockscout.prod.findora.org/address/0xF41cEC0831F9C226Fac2765521A6B5CbfA18Af2D/transactions

## Changelog

### Enhancements
- update balance card template to use FRA instead of Ether
- update tile component template to use FRA instead of Ether

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
